### PR TITLE
Allow passing imagetype to run_phot

### DIFF
--- a/jhat/simple_jwst_phot.py
+++ b/jhat/simple_jwst_phot.py
@@ -1406,7 +1406,8 @@ class jwst_photclass(pdastrostatsclass):
                  Nbright4match=None,
                  xshift=0.0,# added to the x coordinate before calculating ra,dec. This can be used to correct for large shifts before matching!
                  yshift=0.0, # added to the y coordinate before calculating ra,dec. This can be used to correct for large shifts before matching!
-                 ee_radius=70):
+                 ee_radius=70,
+                 imagetype=None):
         if self.verbose:
             print(f'\n### Doing photometry on {imagename}')
         self.ee_radius = ee_radius
@@ -1439,7 +1440,7 @@ class jwst_photclass(pdastrostatsclass):
         
         # load the image, and prepare it. The data and mask are saved in 
         # self.data and self.mask
-        self.load_image(imagename,DNunits=DNunits,use_dq=use_dq)
+        self.load_image(imagename,DNunits=DNunits,use_dq=use_dq,imagetype=imagetype)
         # only do the photometry if not reloaded
         if do_photometry_flag:
     


### PR DESCRIPTION
This fixes the problem in Issue #4, as it allows users to specify that their input images are `cal` files if they change the file name while doing additional calibration before this step. 